### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/ioredis.js
+++ b/lib/ioredis.js
@@ -9,7 +9,7 @@ const Redis = require('ioredis');
 const Redlock = require('redlock');
 const httpError = require('http-errors');
 const Promise = require('bluebird');
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const moment = require('moment');
 const url = require('url');
 

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "loopback-connector": "^2.4.0",
     "loopback-connector-nosql": "^0.1.0",
     "moment": "^2.14.1",
-    "node-uuid": "^1.4.0",
-    "redlock": "^2.0.0"
+    "redlock": "^2.0.0",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.12",

--- a/test/10.crud.test.js
+++ b/test/10.crud.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var should = require('should');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var Promise = require('bluebird');
 
 var init = require('./init');


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.